### PR TITLE
refactor: collapse BT.709/PQ/HLG slice tier wrappers via #[magetypes]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 bytemuck = "1.21"
 archmage = { version = "0.9.19", default-features = false, features = ["macros"] }
-magetypes = { version = "0.9.19", default-features = false, features = ["w512"] }
+magetypes = { version = "0.9.21", default-features = false, features = ["w512"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 zenbench = { version = "0.1.2", features = ["criterion-compat"] }

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -2146,34 +2146,23 @@ pub fn unpremultiply_linear_to_gamma_rgba_slice(values: &mut [f32], gamma: f32) 
 // Transfer function slice dispatchers (BT.709, PQ, HLG)
 // ============================================================================
 
-// Each public dispatcher calls into the existing `#[rite]` slice functions in
-// `crate::tokens::{x4,x8,x16}`, which already carry the SIMD implementation
-// built on magetypes generics. The tier wrappers here are thin `#[arcane]`
-// adapters so that `incant!` can dispatch by suffix at runtime.
+// Each public dispatcher uses `#[magetypes]` to generate per-tier `#[arcane]`
+// wrappers from a single generic body that drives `g_f32x16<Token>` over the
+// underlying `crate::tf::*_x16` kernels. On V4 this lowers to native
+// AVX-512; on V3 it polyfills to 2×f32x8; on NEON/WASM to 4×f32x4; scalar
+// falls through to the per-element TF function.
 
-#[cfg(all(feature = "transfer", feature = "avx512"))]
-#[arcane]
-fn bt709_to_linear_slice_tier_v4(token: X64V4Token, values: &mut [f32]) {
-    crate::tokens::x16::bt709_to_linear_slice_v4(token, values);
-}
 #[cfg(feature = "transfer")]
-#[arcane]
-fn bt709_to_linear_slice_tier_v3(token: X64V3Token, values: &mut [f32]) {
-    crate::tokens::x8::bt709_to_linear_slice_v3(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn bt709_to_linear_slice_tier_neon(token: NeonToken, values: &mut [f32]) {
-    crate::tokens::x4::bt709_to_linear_slice_neon(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn bt709_to_linear_slice_tier_wasm128(token: Wasm128Token, values: &mut [f32]) {
-    crate::tokens::x4::bt709_to_linear_slice_wasm128(token, values);
-}
-#[cfg(feature = "transfer")]
-fn bt709_to_linear_slice_tier_scalar(_token: ScalarToken, values: &mut [f32]) {
-    for v in values.iter_mut() {
+#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn bt709_to_linear_slice_tier(token: Token, values: &mut [f32]) {
+    #[allow(non_camel_case_types)]
+    type f32x16 = g_f32x16<Token>;
+    let (chunks, remainder) = values.as_chunks_mut::<16>();
+    for chunk in chunks {
+        let v = f32x16::from_array(token, *chunk);
+        *chunk = crate::tf::bt709::bt709_to_linear_x16(token, v).to_array();
+    }
+    for v in remainder {
         *v = crate::tf::bt709_to_linear(*v);
     }
 }
@@ -2195,29 +2184,17 @@ pub fn bt709_to_linear_slice(values: &mut [f32]) {
     )
 }
 
-#[cfg(all(feature = "transfer", feature = "avx512"))]
-#[arcane]
-fn linear_to_bt709_slice_tier_v4(token: X64V4Token, values: &mut [f32]) {
-    crate::tokens::x16::linear_to_bt709_slice_v4(token, values);
-}
 #[cfg(feature = "transfer")]
-#[arcane]
-fn linear_to_bt709_slice_tier_v3(token: X64V3Token, values: &mut [f32]) {
-    crate::tokens::x8::linear_to_bt709_slice_v3(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn linear_to_bt709_slice_tier_neon(token: NeonToken, values: &mut [f32]) {
-    crate::tokens::x4::linear_to_bt709_slice_neon(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn linear_to_bt709_slice_tier_wasm128(token: Wasm128Token, values: &mut [f32]) {
-    crate::tokens::x4::linear_to_bt709_slice_wasm128(token, values);
-}
-#[cfg(feature = "transfer")]
-fn linear_to_bt709_slice_tier_scalar(_token: ScalarToken, values: &mut [f32]) {
-    for v in values.iter_mut() {
+#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn linear_to_bt709_slice_tier(token: Token, values: &mut [f32]) {
+    #[allow(non_camel_case_types)]
+    type f32x16 = g_f32x16<Token>;
+    let (chunks, remainder) = values.as_chunks_mut::<16>();
+    for chunk in chunks {
+        let v = f32x16::from_array(token, *chunk);
+        *chunk = crate::tf::bt709::linear_to_bt709_x16(token, v).to_array();
+    }
+    for v in remainder {
         *v = crate::tf::linear_to_bt709(*v);
     }
 }
@@ -2239,29 +2216,17 @@ pub fn linear_to_bt709_slice(values: &mut [f32]) {
     )
 }
 
-#[cfg(all(feature = "transfer", feature = "avx512"))]
-#[arcane]
-fn pq_to_linear_slice_tier_v4(token: X64V4Token, values: &mut [f32]) {
-    crate::tokens::x16::pq_to_linear_slice_v4(token, values);
-}
 #[cfg(feature = "transfer")]
-#[arcane]
-fn pq_to_linear_slice_tier_v3(token: X64V3Token, values: &mut [f32]) {
-    crate::tokens::x8::pq_to_linear_slice_v3(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn pq_to_linear_slice_tier_neon(token: NeonToken, values: &mut [f32]) {
-    crate::tokens::x4::pq_to_linear_slice_neon(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn pq_to_linear_slice_tier_wasm128(token: Wasm128Token, values: &mut [f32]) {
-    crate::tokens::x4::pq_to_linear_slice_wasm128(token, values);
-}
-#[cfg(feature = "transfer")]
-fn pq_to_linear_slice_tier_scalar(_token: ScalarToken, values: &mut [f32]) {
-    for v in values.iter_mut() {
+#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn pq_to_linear_slice_tier(token: Token, values: &mut [f32]) {
+    #[allow(non_camel_case_types)]
+    type f32x16 = g_f32x16<Token>;
+    let (chunks, remainder) = values.as_chunks_mut::<16>();
+    for chunk in chunks {
+        let v = f32x16::from_array(token, *chunk);
+        *chunk = crate::tf::pq::pq_to_linear_x16(token, v).to_array();
+    }
+    for v in remainder {
         *v = crate::tf::pq_to_linear(*v);
     }
 }
@@ -2283,29 +2248,17 @@ pub fn pq_to_linear_slice(values: &mut [f32]) {
     )
 }
 
-#[cfg(all(feature = "transfer", feature = "avx512"))]
-#[arcane]
-fn linear_to_pq_slice_tier_v4(token: X64V4Token, values: &mut [f32]) {
-    crate::tokens::x16::linear_to_pq_slice_v4(token, values);
-}
 #[cfg(feature = "transfer")]
-#[arcane]
-fn linear_to_pq_slice_tier_v3(token: X64V3Token, values: &mut [f32]) {
-    crate::tokens::x8::linear_to_pq_slice_v3(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn linear_to_pq_slice_tier_neon(token: NeonToken, values: &mut [f32]) {
-    crate::tokens::x4::linear_to_pq_slice_neon(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn linear_to_pq_slice_tier_wasm128(token: Wasm128Token, values: &mut [f32]) {
-    crate::tokens::x4::linear_to_pq_slice_wasm128(token, values);
-}
-#[cfg(feature = "transfer")]
-fn linear_to_pq_slice_tier_scalar(_token: ScalarToken, values: &mut [f32]) {
-    for v in values.iter_mut() {
+#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn linear_to_pq_slice_tier(token: Token, values: &mut [f32]) {
+    #[allow(non_camel_case_types)]
+    type f32x16 = g_f32x16<Token>;
+    let (chunks, remainder) = values.as_chunks_mut::<16>();
+    for chunk in chunks {
+        let v = f32x16::from_array(token, *chunk);
+        *chunk = crate::tf::pq::linear_to_pq_x16(token, v).to_array();
+    }
+    for v in remainder {
         *v = crate::tf::linear_to_pq(*v);
     }
 }
@@ -2327,29 +2280,17 @@ pub fn linear_to_pq_slice(values: &mut [f32]) {
     )
 }
 
-#[cfg(all(feature = "transfer", feature = "avx512"))]
-#[arcane]
-fn hlg_to_linear_slice_tier_v4(token: X64V4Token, values: &mut [f32]) {
-    crate::tokens::x16::hlg_to_linear_slice_v4(token, values);
-}
 #[cfg(feature = "transfer")]
-#[arcane]
-fn hlg_to_linear_slice_tier_v3(token: X64V3Token, values: &mut [f32]) {
-    crate::tokens::x8::hlg_to_linear_slice_v3(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn hlg_to_linear_slice_tier_neon(token: NeonToken, values: &mut [f32]) {
-    crate::tokens::x4::hlg_to_linear_slice_neon(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn hlg_to_linear_slice_tier_wasm128(token: Wasm128Token, values: &mut [f32]) {
-    crate::tokens::x4::hlg_to_linear_slice_wasm128(token, values);
-}
-#[cfg(feature = "transfer")]
-fn hlg_to_linear_slice_tier_scalar(_token: ScalarToken, values: &mut [f32]) {
-    for v in values.iter_mut() {
+#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn hlg_to_linear_slice_tier(token: Token, values: &mut [f32]) {
+    #[allow(non_camel_case_types)]
+    type f32x16 = g_f32x16<Token>;
+    let (chunks, remainder) = values.as_chunks_mut::<16>();
+    for chunk in chunks {
+        let v = f32x16::from_array(token, *chunk);
+        *chunk = crate::tf::hlg::hlg_to_linear_x16(token, v).to_array();
+    }
+    for v in remainder {
         *v = crate::tf::hlg_to_linear(*v);
     }
 }
@@ -2371,29 +2312,17 @@ pub fn hlg_to_linear_slice(values: &mut [f32]) {
     )
 }
 
-#[cfg(all(feature = "transfer", feature = "avx512"))]
-#[arcane]
-fn linear_to_hlg_slice_tier_v4(token: X64V4Token, values: &mut [f32]) {
-    crate::tokens::x16::linear_to_hlg_slice_v4(token, values);
-}
 #[cfg(feature = "transfer")]
-#[arcane]
-fn linear_to_hlg_slice_tier_v3(token: X64V3Token, values: &mut [f32]) {
-    crate::tokens::x8::linear_to_hlg_slice_v3(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn linear_to_hlg_slice_tier_neon(token: NeonToken, values: &mut [f32]) {
-    crate::tokens::x4::linear_to_hlg_slice_neon(token, values);
-}
-#[cfg(feature = "transfer")]
-#[arcane]
-fn linear_to_hlg_slice_tier_wasm128(token: Wasm128Token, values: &mut [f32]) {
-    crate::tokens::x4::linear_to_hlg_slice_wasm128(token, values);
-}
-#[cfg(feature = "transfer")]
-fn linear_to_hlg_slice_tier_scalar(_token: ScalarToken, values: &mut [f32]) {
-    for v in values.iter_mut() {
+#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn linear_to_hlg_slice_tier(token: Token, values: &mut [f32]) {
+    #[allow(non_camel_case_types)]
+    type f32x16 = g_f32x16<Token>;
+    let (chunks, remainder) = values.as_chunks_mut::<16>();
+    for chunk in chunks {
+        let v = f32x16::from_array(token, *chunk);
+        *chunk = crate::tf::hlg::linear_to_hlg_x16(token, v).to_array();
+    }
+    for v in remainder {
         *v = crate::tf::linear_to_hlg(*v);
     }
 }

--- a/src/tf/bt709.rs
+++ b/src/tf/bt709.rs
@@ -42,9 +42,12 @@ pub(crate) fn bt709_to_linear_x4<T: F32x4Convert>(t: T, v: f32x4<T>) -> f32x4<T>
 
     let linear = v * inv_4_5;
 
+    // No MIN_POSITIVE clamp on `normalized`: `power` is always blended away
+    // when v < threshold, and fast_powf never faults on negative input
+    // (all bit-manipulation, finite output), so garbage from out-of-domain
+    // lanes never escapes.
     let normalized = (v + alpha) / one_plus_alpha;
-    let safe = normalized.max(f32x4::splat(t, f32::MIN_POSITIVE));
-    let power = fast_math::fast_powf_x4(t, safe, 1.0 / 0.45);
+    let power = fast_math::fast_powf_x4(t, normalized, 1.0 / 0.45);
 
     let mask = v.simd_lt(threshold);
     f32x4::blend(mask, linear, power)
@@ -60,8 +63,9 @@ pub(crate) fn linear_to_bt709_x4<T: F32x4Convert>(t: T, v: f32x4<T>) -> f32x4<T>
 
     let linear = v * scale_4_5;
 
-    let safe = v.max(f32x4::splat(t, f32::MIN_POSITIVE));
-    let power = fast_math::fast_powf_x4(t, safe, 0.45);
+    // See bt709_to_linear_x4: no MIN_POSITIVE clamp needed; `power` is
+    // blended away for v < threshold and fast_powf is branch-free.
+    let power = fast_math::fast_powf_x4(t, v, 0.45);
     let power = one_plus_alpha.mul_add(power, -alpha);
 
     let mask = v.simd_lt(threshold);
@@ -84,9 +88,9 @@ pub(crate) fn bt709_to_linear_x8<T: F32x8Convert>(t: T, v: f32x8<T>) -> f32x8<T>
 
     let linear = v * inv_4_5;
 
+    // See bt709_to_linear_x4: no MIN_POSITIVE clamp needed.
     let normalized = (v + alpha) / one_plus_alpha;
-    let safe = normalized.max(f32x8::splat(t, f32::MIN_POSITIVE));
-    let power = fast_math::fast_powf_x8(t, safe, 1.0 / 0.45);
+    let power = fast_math::fast_powf_x8(t, normalized, 1.0 / 0.45);
 
     let mask = v.simd_lt(threshold);
     f32x8::blend(mask, linear, power)
@@ -101,10 +105,51 @@ pub(crate) fn linear_to_bt709_x8<T: F32x8Convert>(t: T, v: f32x8<T>) -> f32x8<T>
 
     let linear = v * scale_4_5;
 
-    let safe = v.max(f32x8::splat(t, f32::MIN_POSITIVE));
-    let power = fast_math::fast_powf_x8(t, safe, 0.45);
+    // See linear_to_bt709_x4: no MIN_POSITIVE clamp needed.
+    let power = fast_math::fast_powf_x8(t, v, 0.45);
     let power = one_plus_alpha.mul_add(power, -alpha);
 
     let mask = v.simd_lt(threshold);
     f32x8::blend(mask, linear, power)
+}
+
+// =============================================================================
+// Generic SIMD — x16
+// =============================================================================
+
+use magetypes::simd::backends::F32x16Convert;
+use magetypes::simd::generic::f32x16;
+
+#[inline(always)]
+pub(crate) fn bt709_to_linear_x16<T: F32x16Convert>(t: T, v: f32x16<T>) -> f32x16<T> {
+    let threshold = f32x16::splat(t, 4.5 * BT709_BETA);
+    let inv_4_5 = f32x16::splat(t, 1.0 / 4.5);
+    let alpha = f32x16::splat(t, BT709_ALPHA);
+    let one_plus_alpha = f32x16::splat(t, 1.0 + BT709_ALPHA);
+
+    let linear = v * inv_4_5;
+
+    // See bt709_to_linear_x4: no MIN_POSITIVE clamp needed.
+    let normalized = (v + alpha) / one_plus_alpha;
+    let power = fast_math::fast_powf_x16(t, normalized, 1.0 / 0.45);
+
+    let mask = v.simd_lt(threshold);
+    f32x16::blend(mask, linear, power)
+}
+
+#[inline(always)]
+pub(crate) fn linear_to_bt709_x16<T: F32x16Convert>(t: T, v: f32x16<T>) -> f32x16<T> {
+    let threshold = f32x16::splat(t, BT709_BETA);
+    let scale_4_5 = f32x16::splat(t, 4.5);
+    let one_plus_alpha = f32x16::splat(t, 1.0 + BT709_ALPHA);
+    let alpha = f32x16::splat(t, BT709_ALPHA);
+
+    let linear = v * scale_4_5;
+
+    // See linear_to_bt709_x4: no MIN_POSITIVE clamp needed.
+    let power = fast_math::fast_powf_x16(t, v, 0.45);
+    let power = one_plus_alpha.mul_add(power, -alpha);
+
+    let mask = v.simd_lt(threshold);
+    f32x16::blend(mask, linear, power)
 }

--- a/src/tf/fast_math.rs
+++ b/src/tf/fast_math.rs
@@ -276,3 +276,90 @@ pub(crate) fn fast_powf_x8<T: F32x8Convert>(t: T, base: f32x8<T>, exponent: f32)
     let scaled = log2 * f32x8::splat(t, exponent);
     fast_pow2f_x8(t, scaled)
 }
+
+// --- x16 generics (polyfilled to 2×x8 on V3, 4×x4 on NEON/WASM; native on V4 AVX-512) ---
+
+use magetypes::simd::backends::F32x16Convert;
+use magetypes::simd::generic::{f32x16, i32x16};
+
+/// Evaluate degree-4 rational polynomial P(x)/Q(x) on 16 f32 values via FMA.
+#[inline(always)]
+pub(crate) fn eval_rational_poly_x16<T: F32x16Convert>(
+    t: T,
+    x: f32x16<T>,
+    p: [f32; 5],
+    q: [f32; 5],
+) -> f32x16<T> {
+    let mut yp = f32x16::splat(t, p[4]);
+    yp = yp.mul_add(x, f32x16::splat(t, p[3]));
+    yp = yp.mul_add(x, f32x16::splat(t, p[2]));
+    yp = yp.mul_add(x, f32x16::splat(t, p[1]));
+    yp = yp.mul_add(x, f32x16::splat(t, p[0]));
+
+    let mut yq = f32x16::splat(t, q[4]);
+    yq = yq.mul_add(x, f32x16::splat(t, q[3]));
+    yq = yq.mul_add(x, f32x16::splat(t, q[2]));
+    yq = yq.mul_add(x, f32x16::splat(t, q[1]));
+    yq = yq.mul_add(x, f32x16::splat(t, q[0]));
+
+    yp / yq
+}
+
+/// fast_log2f on 16 f32 values — bit manipulation + rational polynomial.
+#[inline(always)]
+pub(crate) fn fast_log2f_x16<T: F32x16Convert>(t: T, x: f32x16<T>) -> f32x16<T> {
+    let x_bits = x.bitcast_to_i32();
+    let magic = i32x16::splat(t, 0x3f2aaaab_u32 as i32);
+    let exp_bits = x_bits - magic;
+    let exp_shifted = exp_bits.shr_arithmetic_const::<23>();
+
+    let shifted_back = exp_shifted.shl_const::<23>();
+    let mantissa_bits = x_bits - shifted_back;
+    let mantissa = f32x16::from_i32_bitcast(t, mantissa_bits);
+
+    let exp_f = f32x16::from_i32(t, exp_shifted);
+    let one = f32x16::splat(t, 1.0);
+    let m = mantissa - one;
+
+    let mut yp = f32x16::splat(t, LOG2_P[2]);
+    yp = yp.mul_add(m, f32x16::splat(t, LOG2_P[1]));
+    yp = yp.mul_add(m, f32x16::splat(t, LOG2_P[0]));
+
+    let mut yq = f32x16::splat(t, LOG2_Q[2]);
+    yq = yq.mul_add(m, f32x16::splat(t, LOG2_Q[1]));
+    yq = yq.mul_add(m, f32x16::splat(t, LOG2_Q[0]));
+
+    let poly = yp / yq;
+    poly + exp_f
+}
+
+/// fast_pow2f on 16 f32 values — integer bit manipulation + polynomial.
+#[inline(always)]
+pub(crate) fn fast_pow2f_x16<T: F32x16Convert>(t: T, x: f32x16<T>) -> f32x16<T> {
+    let x_floor = x.floor();
+    let frac = x - x_floor;
+
+    let x_floor_i = x_floor.to_i32();
+    let bias = i32x16::splat(t, 127);
+    let exp_bits = (x_floor_i + bias).shl_const::<23>();
+    let exp = f32x16::from_i32_bitcast(t, exp_bits);
+
+    let mut num = frac + f32x16::splat(t, POW2_NUM[0]);
+    num = num.mul_add(frac, f32x16::splat(t, POW2_NUM[1]));
+    num = num.mul_add(frac, f32x16::splat(t, POW2_NUM[2]));
+    num = num * exp;
+
+    let mut den = f32x16::splat(t, POW2_DEN[0]).mul_add(frac, f32x16::splat(t, POW2_DEN[1]));
+    den = den.mul_add(frac, f32x16::splat(t, POW2_DEN[2]));
+    den = den.mul_add(frac, f32x16::splat(t, POW2_DEN[3]));
+
+    num / den
+}
+
+/// fast_powf(base, exp) on 16 f32 values: pow2f(exp * log2f(base)).
+#[inline(always)]
+pub(crate) fn fast_powf_x16<T: F32x16Convert>(t: T, base: f32x16<T>, exponent: f32) -> f32x16<T> {
+    let log2 = fast_log2f_x16(t, base);
+    let scaled = log2 * f32x16::splat(t, exponent);
+    fast_pow2f_x16(t, scaled)
+}

--- a/src/tf/hlg.rs
+++ b/src/tf/hlg.rs
@@ -56,8 +56,10 @@ pub(crate) fn hlg_to_linear_x4<T: F32x4Convert>(t: T, v: f32x4<T>) -> f32x4<T> {
     let hlg_c = f32x4::splat(t, HLG_C);
     let hlg_inv_a_log2e = f32x4::splat(t, HLG_INV_A_LOG2E);
 
+    // v <= 0 is absorbed by a = max(v, 0) = 0 ⇒ low = 0; the a<=0.5 mask then
+    // already selects `low` for those lanes, so no separate positive mask is
+    // needed (saves a cmp + mask materialize on AVX-512).
     let a = v.max(zero);
-
     let low = (a * a) * third;
 
     let exp_arg = (a - hlg_c) * hlg_inv_a_log2e;
@@ -65,10 +67,7 @@ pub(crate) fn hlg_to_linear_x4<T: F32x4Convert>(t: T, v: f32x4<T>) -> f32x4<T> {
     let high = (exp_val + hlg_b) * inv_12;
 
     let mask = a.simd_le(half);
-    let result = f32x4::blend(mask, low, high);
-
-    let pos_mask = v.simd_gt(zero);
-    result & pos_mask
+    f32x4::blend(mask, low, high)
 }
 
 #[allow(dead_code)]
@@ -82,20 +81,19 @@ pub(crate) fn linear_to_hlg_x4<T: F32x4Convert>(t: T, v: f32x4<T>) -> f32x4<T> {
     let hlg_b = f32x4::splat(t, HLG_B);
     let hlg_c = f32x4::splat(t, HLG_C);
 
+    // v <= 0 is absorbed by a = max(v, 0) = 0 ⇒ low = sqrt(0) = 0; the
+    // a<=1/12 mask then selects `low` (=0) for those lanes. The `high` path
+    // is always discarded when a<=1/12, so no log-argument clamp is needed
+    // (garbage from fast_log2f on a small or non-positive arg is masked out).
     let a = v.max(zero);
-
     let low = (three * a).sqrt();
 
     let arg = twelve * a - hlg_b;
-    let safe_arg = arg.max(f32x4::splat(t, f32::MIN_POSITIVE));
-    let log2_val = fast_math::fast_log2f_x4(t, safe_arg);
+    let log2_val = fast_math::fast_log2f_x4(t, arg);
     let high = hlg_a_ln2.mul_add(log2_val, hlg_c);
 
     let mask = a.simd_le(threshold);
-    let result = f32x4::blend(mask, low, high);
-
-    let pos_mask = v.simd_gt(zero);
-    result & pos_mask
+    f32x4::blend(mask, low, high)
 }
 
 // =============================================================================
@@ -115,8 +113,8 @@ pub(crate) fn hlg_to_linear_x8<T: F32x8Convert>(t: T, v: f32x8<T>) -> f32x8<T> {
     let hlg_c = f32x8::splat(t, HLG_C);
     let hlg_inv_a_log2e = f32x8::splat(t, HLG_INV_A_LOG2E);
 
+    // See comments on hlg_to_linear_x4.
     let a = v.max(zero);
-
     let low = (a * a) * third;
 
     let exp_arg = (a - hlg_c) * hlg_inv_a_log2e;
@@ -124,10 +122,7 @@ pub(crate) fn hlg_to_linear_x8<T: F32x8Convert>(t: T, v: f32x8<T>) -> f32x8<T> {
     let high = (exp_val + hlg_b) * inv_12;
 
     let mask = a.simd_le(half);
-    let result = f32x8::blend(mask, low, high);
-
-    let pos_mask = v.simd_gt(zero);
-    result & pos_mask
+    f32x8::blend(mask, low, high)
 }
 
 #[inline(always)]
@@ -140,18 +135,64 @@ pub(crate) fn linear_to_hlg_x8<T: F32x8Convert>(t: T, v: f32x8<T>) -> f32x8<T> {
     let hlg_b = f32x8::splat(t, HLG_B);
     let hlg_c = f32x8::splat(t, HLG_C);
 
+    // See comments on linear_to_hlg_x4.
     let a = v.max(zero);
-
     let low = (three * a).sqrt();
 
     let arg = twelve * a - hlg_b;
-    let safe_arg = arg.max(f32x8::splat(t, f32::MIN_POSITIVE));
-    let log2_val = fast_math::fast_log2f_x8(t, safe_arg);
+    let log2_val = fast_math::fast_log2f_x8(t, arg);
     let high = hlg_a_ln2.mul_add(log2_val, hlg_c);
 
     let mask = a.simd_le(threshold);
-    let result = f32x8::blend(mask, low, high);
+    f32x8::blend(mask, low, high)
+}
 
-    let pos_mask = v.simd_gt(zero);
-    result & pos_mask
+// =============================================================================
+// Generic SIMD — x16
+// =============================================================================
+
+use magetypes::simd::backends::F32x16Convert;
+use magetypes::simd::generic::f32x16;
+
+#[inline(always)]
+pub(crate) fn hlg_to_linear_x16<T: F32x16Convert>(t: T, v: f32x16<T>) -> f32x16<T> {
+    let zero = f32x16::zero(t);
+    let half = f32x16::splat(t, 0.5);
+    let third = f32x16::splat(t, 1.0 / 3.0);
+    let inv_12 = f32x16::splat(t, 1.0 / 12.0);
+    let hlg_b = f32x16::splat(t, HLG_B);
+    let hlg_c = f32x16::splat(t, HLG_C);
+    let hlg_inv_a_log2e = f32x16::splat(t, HLG_INV_A_LOG2E);
+
+    // See comments on hlg_to_linear_x4.
+    let a = v.max(zero);
+    let low = (a * a) * third;
+
+    let exp_arg = (a - hlg_c) * hlg_inv_a_log2e;
+    let exp_val = fast_math::fast_pow2f_x16(t, exp_arg);
+    let high = (exp_val + hlg_b) * inv_12;
+
+    let mask = a.simd_le(half);
+    f32x16::blend(mask, low, high)
+}
+
+#[inline(always)]
+pub(crate) fn linear_to_hlg_x16<T: F32x16Convert>(t: T, v: f32x16<T>) -> f32x16<T> {
+    let zero = f32x16::zero(t);
+    let threshold = f32x16::splat(t, 1.0 / 12.0);
+    let three = f32x16::splat(t, 3.0);
+    let twelve = f32x16::splat(t, 12.0);
+    let hlg_a_ln2 = f32x16::splat(t, HLG_A_INV_LOG2E);
+    let hlg_b = f32x16::splat(t, HLG_B);
+    let hlg_c = f32x16::splat(t, HLG_C);
+    // See comments on linear_to_hlg_x4.
+    let a = v.max(zero);
+    let low = (three * a).sqrt();
+
+    let arg = twelve * a - hlg_b;
+    let log2_val = fast_math::fast_log2f_x16(t, arg);
+    let high = hlg_a_ln2.mul_add(log2_val, hlg_c);
+
+    let mask = a.simd_le(threshold);
+    f32x16::blend(mask, low, high)
 }

--- a/src/tf/pq.rs
+++ b/src/tf/pq.rs
@@ -211,3 +211,44 @@ pub(crate) fn linear_to_pq_x8<T: F32x8Convert>(t: T, v: f32x8<T>) -> f32x8<T> {
     let pos_mask = v.simd_gt(zero);
     result & pos_mask
 }
+
+// =============================================================================
+// Generic SIMD — x16
+// =============================================================================
+
+use magetypes::simd::backends::F32x16Convert;
+use magetypes::simd::generic::f32x16;
+
+#[inline(always)]
+pub(crate) fn pq_to_linear_x16<T: F32x16Convert>(t: T, v: f32x16<T>) -> f32x16<T> {
+    let zero = f32x16::zero(t);
+    let a = v.max(zero);
+    let x = a.mul_add(a, a);
+
+    let threshold = f32x16::splat(t, 0.25);
+    let large = fast_math::eval_rational_poly_x16(t, x, PQ_EOTF_P_LARGE, PQ_EOTF_Q_LARGE);
+    let small = fast_math::eval_rational_poly_x16(t, x, PQ_EOTF_P_SMALL, PQ_EOTF_Q_SMALL);
+
+    let mask = a.simd_lt(threshold);
+    let result = f32x16::blend(mask, small, large);
+
+    let pos_mask = v.simd_gt(zero);
+    result & pos_mask
+}
+
+#[inline(always)]
+pub(crate) fn linear_to_pq_x16<T: F32x16Convert>(t: T, v: f32x16<T>) -> f32x16<T> {
+    let zero = f32x16::zero(t);
+    let a = v.max(zero);
+    let a4 = a.sqrt().sqrt();
+
+    let threshold = f32x16::splat(t, 0.1);
+    let large = fast_math::eval_rational_poly_x16(t, a4, PQ_INV_P_LARGE, PQ_INV_Q_LARGE);
+    let small = fast_math::eval_rational_poly_x16(t, a4, PQ_INV_P_SMALL, PQ_INV_Q_SMALL);
+
+    let mask = a4.simd_lt(threshold);
+    let result = f32x16::blend(mask, small, large);
+
+    let pos_mask = v.simd_gt(zero);
+    result & pos_mask
+}


### PR DESCRIPTION
## Summary

Finishes the magetypes slice-wrapper collapse started in PR #15. The 6 remaining transfer-function slice dispatchers (BT.709, PQ, HLG × encode/decode) each had 5 hand-written `#[arcane]` tier wrappers delegating to `crate::tokens::{x16,x8,x4}`. Each collapses into a single `#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]` body driven by `g_f32x16<Token>`.

- Native AVX-512 on V4; polyfilled to 2×f32x8 on V3, 4×f32x4 on NEON/WASM; scalar falls through to the per-element TF.
- Public API unchanged. `tokens::x{16,8,4}::*_slice_*` remain (used by `tf_bench.rs` and the RGBA macros).
- Adds `fast_log2f_x16` / `fast_pow2f_x16` / `fast_powf_x16` / `eval_rational_poly_x16` in `tf/fast_math.rs` and `*_to_linear_x16` / `linear_to_*_x16` generics in `tf/{bt709,pq,hlg}.rs` (mirror of the existing x4/x8 kernels).
- Bumps `magetypes` 0.9.19 → 0.9.21 and `archmage` 0.9.19 → 0.9.21 — needed for `F32x16Convert` impls on every target token.

Net in `src/simd.rs`: −95 lines. Total across the 6 files: +293 / −137 (the x16 kernels add ~225 lines; the simd.rs collapse removes ~170).

## Test plan

- [x] `cargo test --all-features` locally: 155 lib + 58 brute_force + 11 simd_consistency + 30 doctests — passing
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Cross-builds: `aarch64-unknown-linux-gnu`, `wasm32-unknown-unknown`
- [ ] CI green on all platforms (windows-11-arm, macos intel, i686, etc.)