### PR TITLE
refactor: collapse sRGB extended-range slice tier wrappers via #[magetypes]

### DIFF
--- a/src/simd.rs
+++ b/src/simd.rs
@@ -524,35 +524,16 @@ pub fn linear_to_srgb_rgba_slice(values: &mut [f32]) {
 // Extended-range sRGB ↔ Linear Slice Functions (no clamping)
 // ============================================================================
 
-#[arcane]
-fn srgb_to_linear_extended_slice_tier_v3(token: X64V3Token, values: &mut [f32]) {
-    crate::tokens::x8::srgb_to_linear_extended_slice_v3(token, values);
-}
-
-#[arcane]
-fn srgb_to_linear_extended_slice_tier_neon(token: NeonToken, values: &mut [f32]) {
-    let (chunks, remainder) = values.as_chunks_mut::<4>();
+#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn srgb_to_linear_extended_slice_tier(token: Token, values: &mut [f32]) {
+    #[allow(non_camel_case_types)]
+    type f32x16 = g_f32x16<Token>;
+    let (chunks, remainder) = values.as_chunks_mut::<16>();
     for chunk in chunks {
-        *chunk = crate::tokens::x4::srgb_to_linear_extended_neon(token, *chunk);
+        let v = f32x16::from_array(token, *chunk);
+        *chunk = crate::tf::srgb::srgb_to_linear_extended_x16(token, v).to_array();
     }
     for v in remainder {
-        *v = crate::scalar::srgb_to_linear_extended(*v);
-    }
-}
-
-#[arcane]
-fn srgb_to_linear_extended_slice_tier_wasm128(token: Wasm128Token, values: &mut [f32]) {
-    let (chunks, remainder) = values.as_chunks_mut::<4>();
-    for chunk in chunks {
-        *chunk = crate::tokens::x4::srgb_to_linear_extended_wasm128(token, *chunk);
-    }
-    for v in remainder {
-        *v = crate::scalar::srgb_to_linear_extended(*v);
-    }
-}
-
-fn srgb_to_linear_extended_slice_tier_scalar(_token: ScalarToken, values: &mut [f32]) {
-    for v in values.iter_mut() {
         *v = crate::scalar::srgb_to_linear_extended(*v);
     }
 }
@@ -595,39 +576,20 @@ fn srgb_to_linear_extended_slice_tier_scalar(_token: ScalarToken, values: &mut [
 pub fn srgb_to_linear_extended_slice(values: &mut [f32]) {
     incant!(
         srgb_to_linear_extended_slice_tier(values),
-        [v3, neon, wasm128, scalar]
+        [v4, v3, neon, wasm128, scalar]
     )
 }
 
-#[arcane]
-fn linear_to_srgb_extended_slice_tier_v3(token: X64V3Token, values: &mut [f32]) {
-    crate::tokens::x8::linear_to_srgb_extended_slice_v3(token, values);
-}
-
-#[arcane]
-fn linear_to_srgb_extended_slice_tier_neon(token: NeonToken, values: &mut [f32]) {
-    let (chunks, remainder) = values.as_chunks_mut::<4>();
+#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn linear_to_srgb_extended_slice_tier(token: Token, values: &mut [f32]) {
+    #[allow(non_camel_case_types)]
+    type f32x16 = g_f32x16<Token>;
+    let (chunks, remainder) = values.as_chunks_mut::<16>();
     for chunk in chunks {
-        *chunk = crate::tokens::x4::linear_to_srgb_extended_neon(token, *chunk);
+        let v = f32x16::from_array(token, *chunk);
+        *chunk = crate::tf::srgb::linear_to_srgb_extended_x16(token, v).to_array();
     }
     for v in remainder {
-        *v = crate::scalar::linear_to_srgb_extended(*v);
-    }
-}
-
-#[arcane]
-fn linear_to_srgb_extended_slice_tier_wasm128(token: Wasm128Token, values: &mut [f32]) {
-    let (chunks, remainder) = values.as_chunks_mut::<4>();
-    for chunk in chunks {
-        *chunk = crate::tokens::x4::linear_to_srgb_extended_wasm128(token, *chunk);
-    }
-    for v in remainder {
-        *v = crate::scalar::linear_to_srgb_extended(*v);
-    }
-}
-
-fn linear_to_srgb_extended_slice_tier_scalar(_token: ScalarToken, values: &mut [f32]) {
-    for v in values.iter_mut() {
         *v = crate::scalar::linear_to_srgb_extended(*v);
     }
 }
@@ -668,7 +630,7 @@ fn linear_to_srgb_extended_slice_tier_scalar(_token: ScalarToken, values: &mut [
 pub fn linear_to_srgb_extended_slice(values: &mut [f32]) {
     incant!(
         linear_to_srgb_extended_slice_tier(values),
-        [v3, neon, wasm128, scalar]
+        [v4, v3, neon, wasm128, scalar]
     )
 }
 

--- a/src/tf/srgb.rs
+++ b/src/tf/srgb.rs
@@ -74,3 +74,74 @@ pub(crate) fn linear_to_srgb_x8<T: F32x8Convert>(t: T, v: f32x8<T>) -> f32x8<T> 
     let mask = v.simd_le(threshold);
     f32x8::blend(mask, linear, poly)
 }
+
+// =============================================================================
+// Extended-range (sign-preserving, 6/6 rational polynomial) — x16
+// =============================================================================
+
+use magetypes::simd::backends::F32x16Backend;
+use magetypes::simd::generic::f32x16;
+
+/// Extended-range sRGB→linear, 16-wide. `sign(v) * eotf(|v|)` per CSS Color 4.
+#[inline(always)]
+pub(crate) fn srgb_to_linear_extended_x16<T: F32x16Backend>(t: T, v: f32x16<T>) -> f32x16<T> {
+    use rational_poly::{EXT_S2L_P as P, EXT_S2L_Q as Q};
+    let zero = f32x16::zero(t);
+    let neg_mask = v.simd_lt(zero);
+    let abs_v = v.abs();
+
+    let linear_result = abs_v * f32x16::splat(t, rational_poly::LINEAR_SCALE);
+
+    let x = abs_v;
+    let yp = f32x16::splat(t, P[6]).mul_add(x, f32x16::splat(t, P[5]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[4]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[3]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[2]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[1]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[0]));
+
+    let yq = f32x16::splat(t, Q[6]).mul_add(x, f32x16::splat(t, Q[5]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[4]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[3]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[2]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[1]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[0]));
+
+    let power_result = yp / yq;
+
+    let thresh_mask = abs_v.simd_lt(f32x16::splat(t, rational_poly::SRGB_THRESHOLD));
+    let result = f32x16::blend(thresh_mask, linear_result, power_result);
+    f32x16::blend(neg_mask, -result, result)
+}
+
+/// Extended-range linear→sRGB, 16-wide. `sign(v) * oetf(|v|)` per CSS Color 4.
+#[inline(always)]
+pub(crate) fn linear_to_srgb_extended_x16<T: F32x16Backend>(t: T, v: f32x16<T>) -> f32x16<T> {
+    use rational_poly::{EXT_L2S_P as P, EXT_L2S_Q as Q};
+    let zero = f32x16::zero(t);
+    let neg_mask = v.simd_lt(zero);
+    let abs_v = v.abs();
+
+    let linear_result = abs_v * f32x16::splat(t, rational_poly::TWELVE_92);
+
+    let x = abs_v.sqrt();
+    let yp = f32x16::splat(t, P[6]).mul_add(x, f32x16::splat(t, P[5]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[4]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[3]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[2]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[1]));
+    let yp = yp.mul_add(x, f32x16::splat(t, P[0]));
+
+    let yq = f32x16::splat(t, Q[6]).mul_add(x, f32x16::splat(t, Q[5]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[4]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[3]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[2]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[1]));
+    let yq = yq.mul_add(x, f32x16::splat(t, Q[0]));
+
+    let power_result = yp / yq;
+
+    let thresh_mask = abs_v.simd_lt(f32x16::splat(t, rational_poly::LINEAR_THRESHOLD));
+    let result = f32x16::blend(thresh_mask, linear_result, power_result);
+    f32x16::blend(neg_mask, -result, result)
+}


### PR DESCRIPTION
## Summary

Continues the magetypes tier-wrapper collapse from PRs #15 / #16. The two extended-range sRGB slice dispatchers (`srgb_to_linear_extended_slice`, `linear_to_srgb_extended_slice`) had 3 hand-written `#[arcane]` tier wrappers each (V3 / NEON / WASM), with no AVX-512 path. Each collapses into a single `#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]` body driven by `g_f32x16<Token>`.

- **Adds an AVX-512 path** that the extended dispatchers previously lacked. On V4 the x16 body lowers to native 16-wide; on V3 polyfills to 2×f32x8 (same shape as the former x8 slice call); on NEON/WASM to 4×f32x4.
- Adds `srgb_to_linear_extended_x16<T: F32x16Backend>` and `linear_to_srgb_extended_x16<T: F32x16Backend>` generic kernels in `src/tf/srgb.rs`, mirroring the existing `_x4` / `_x8` clamped helpers. Uses the same `EXT_S2L_P/Q` and `EXT_L2S_P/Q` 6/6 rational polynomials — no change to math.
- Public API unchanged. `tokens::x{4,8}::*_extended_*` remain for existing consumers.

`src/simd.rs`: −46 lines. Total: +87 / −54 (the x16 kernels add ~75 lines).

## Test plan

- [x] `cargo test --all-features` locally: 155 lib + 58 brute_force + 11 simd_consistency + 30 doctests — passing
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Cross-builds: `aarch64-unknown-linux-gnu`, `wasm32-unknown-unknown`
- [ ] CI green on all platforms (windows-11-arm, macos intel, i686, etc.)