### PR TITLE
tooling: add tango-bench regression gate vs published crate

### DIFF
--- a/tango/.gitignore
+++ b/tango/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/tango/Cargo.toml
+++ b/tango/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "linear-srgb-tango"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+# Standalone package for paired-benchmark regression testing against the
+# published `linear-srgb` crate. See README.md for usage.
+#
+# The default here depends on the crates.io-published version; this build
+# produces the BASELINE binary. To test a local WIP, uncomment the
+# `[patch.crates-io]` block at the bottom, rebuild, and run in `compare`
+# mode against the saved baseline.
+
+[dependencies]
+linear-srgb = { version = "=0.6.11", default-features = false, features = [
+    "std",
+    "avx512",
+    "transfer",
+] }
+
+[dev-dependencies]
+tango-bench = "0.7.2"
+
+[[bench]]
+name = "regression"
+harness = false
+
+# To run the WIP version against the saved baseline binary, uncomment:
+#
+# [patch.crates-io]
+# linear-srgb = { path = ".." }

--- a/tango/README.md
+++ b/tango/README.md
@@ -1,0 +1,62 @@
+# linear-srgb tango regression bench
+
+Paired-benchmark regression gate that compares the **local WIP** linear-srgb
+against the **published crates.io version** (currently `=0.6.11`).
+
+Uses [tango-bench](https://crates.io/crates/tango-bench) so the two versions
+run in the *same* process, interleaved microsecond-by-microsecond, and tango
+reports a paired A/B percentage per benchmark. This is far more sensitive
+than back-to-back cargo bench runs — fractions of a percent are detectable.
+
+## One-time setup
+
+Nothing — just have `cargo export` available (`cargo install cargo-export`).
+
+## Workflow
+
+```bash
+# 1. Build the BASELINE binary against the published crate.
+#    (Cargo.toml defaults to `linear-srgb = "=0.6.11"` from crates.io.)
+cd tango
+cargo export target/baseline -- bench --bench regression
+
+# 2. Enable the local WIP by uncommenting the [patch.crates-io] block at
+#    the bottom of Cargo.toml:
+#        [patch.crates-io]
+#        linear-srgb = { path = ".." }
+#    (Or: `sed -i 's/^# \[patch/[patch/; s/^# linear-srgb = { path/linear-srgb = { path/' Cargo.toml`.)
+
+# 3. Build + compare against the saved baseline.
+cargo bench --bench regression -- compare target/baseline/regression
+
+# 4. Don't forget to re-comment [patch.crates-io] when done (or `git checkout Cargo.toml`).
+```
+
+## Interpreting output
+
+Tango prints one line per benchmark:
+
+```
+linear_to_hlg_uniform_4096    [ 2.44µs ... 2.55µs ]   +4.5%*
+```
+
+- Left = WIP timing, right = baseline timing.
+- Sign on the delta is relative to baseline; `*` means the 95% CI excludes zero.
+- **Positive = WIP slower = regression.** Negative = WIP faster.
+
+## Benchmarks covered
+
+All six transfer-function slice dispatchers:
+- `linear_to_hlg`, `hlg_to_linear`
+- `linear_to_bt709`, `bt709_to_linear`
+- `linear_to_pq`, `pq_to_linear`
+
+Four input distributions × three sizes (256, 4096, 8192):
+- `uniform` — evenly distributed across [0, 1]
+- `small` — all values in [0, 1/16], forces the quadratic / linear / small-poly branch
+- `large` — all values in [0.2, 1.0], forces the log / sinh / large-poly branch
+- `hdr_luma` — cube of uniform, approximates HDR luma distribution (~44% below HLG split)
+
+The size axis is there to catch per-call SIMD setup dominating small slices
+(issue #18 reported a 30% regression at 256 that narrowed to 12% at 1080p
+as memory bandwidth took over).

--- a/tango/benches/regression.rs
+++ b/tango/benches/regression.rs
@@ -1,0 +1,112 @@
+//! Paired-benchmark regression gate for linear-srgb slice dispatchers.
+//!
+//! Run as a tango-bench binary. Build once against the published baseline,
+//! then rebuild with `[patch.crates-io]` pointing at the local WIP and
+//! invoke in `compare` mode. See `tango/README.md`.
+
+use std::hint::black_box;
+
+use linear_srgb::default::{
+    bt709_to_linear_slice, hlg_to_linear_slice, linear_to_bt709_slice, linear_to_hlg_slice,
+    linear_to_pq_slice, pq_to_linear_slice,
+};
+use tango_bench::{IntoBenchmarks, benchmark_fn, tango_benchmarks, tango_main};
+
+// Sizes chosen to probe three regimes that behave differently in the issue #18
+// regression: per-call overhead (256), typical tile-scanline (4096), and
+// bandwidth-bound (~1080p width * 4 channels, 8192 floats).
+const SIZES: &[usize] = &[256, 4096, 8192];
+
+// Four input distributions so a regression on one branch of the TF kernel
+// shows up even if the averaged-mixed case hides it. All map to f32 values
+// already in the [0, 1] signal / linear domain used by HLG, BT.709, PQ.
+fn dist_uniform(n: usize) -> Vec<f32> {
+    (0..n).map(|i| (i as f32) / (n as f32)).collect()
+}
+
+fn dist_all_small(n: usize) -> Vec<f32> {
+    // Forces the quadratic / linear branch on linear_to_hlg, the linear
+    // branch on bt709, and the small-poly branch on PQ.
+    (0..n).map(|i| 0.0625 * (i as f32) / (n as f32)).collect()
+}
+
+fn dist_all_large(n: usize) -> Vec<f32> {
+    // Forces the log / sinh / large-poly branch.
+    (0..n)
+        .map(|i| 0.2 + 0.8 * (i as f32) / (n as f32))
+        .collect()
+}
+
+fn dist_hdr_luma(n: usize) -> Vec<f32> {
+    // Approximates measured HDR luma distribution — ~44% below HLG split.
+    (0..n)
+        .map(|i| {
+            let x = (i as f32) / (n as f32);
+            (x * x * x).clamp(0.0, 1.0)
+        })
+        .collect()
+}
+
+struct Case {
+    label: &'static str,
+    data: Vec<f32>,
+}
+
+fn cases() -> Vec<Case> {
+    let mut out = Vec::new();
+    for &n in SIZES {
+        out.push(Case {
+            label: leak_label(&format!("uniform_{n}")),
+            data: dist_uniform(n),
+        });
+        out.push(Case {
+            label: leak_label(&format!("small_{n}")),
+            data: dist_all_small(n),
+        });
+        out.push(Case {
+            label: leak_label(&format!("large_{n}")),
+            data: dist_all_large(n),
+        });
+        out.push(Case {
+            label: leak_label(&format!("hdr_luma_{n}")),
+            data: dist_hdr_luma(n),
+        });
+    }
+    out
+}
+
+fn leak_label(s: &str) -> &'static str {
+    Box::leak(s.to_owned().into_boxed_str())
+}
+
+fn bench_fn(
+    prefix: &'static str,
+    op: fn(&mut [f32]),
+) -> impl IntoIterator<Item = tango_bench::Benchmark> {
+    cases().into_iter().map(move |case| {
+        let data = case.data.clone();
+        let label = leak_label(&format!("{prefix}_{}", case.label));
+        benchmark_fn(label, move |b| {
+            let mut buf = data.clone();
+            let src = data.clone();
+            b.iter(move || {
+                buf.copy_from_slice(&src);
+                op(black_box(&mut buf));
+            })
+        })
+    })
+}
+
+fn benchmarks() -> impl IntoBenchmarks {
+    let mut out: Vec<tango_bench::Benchmark> = Vec::new();
+    out.extend(bench_fn("linear_to_hlg", linear_to_hlg_slice));
+    out.extend(bench_fn("hlg_to_linear", hlg_to_linear_slice));
+    out.extend(bench_fn("linear_to_bt709", linear_to_bt709_slice));
+    out.extend(bench_fn("bt709_to_linear", bt709_to_linear_slice));
+    out.extend(bench_fn("linear_to_pq", linear_to_pq_slice));
+    out.extend(bench_fn("pq_to_linear", pq_to_linear_slice));
+    out
+}
+
+tango_benchmarks!(benchmarks());
+tango_main!();

--- a/tango/build.rs
+++ b/tango/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // tango-bench requires rustc to export symbols for dynamic linking from
+    // benchmark binaries so the `compare` mode can load the baseline binary.
+    println!("cargo:rustc-link-arg-benches=-rdynamic");
+    println!("cargo:rerun-if-changed=build.rs");
+}


### PR DESCRIPTION
## Summary

Adds `tango/` — a standalone Rust package that uses [tango-bench](https://crates.io/crates/tango-bench) for **paired-benchmark regression testing against the published `linear-srgb` crate** on crates.io. The two versions run interleaved in the same process so tango can report a paired A/B percentage per benchmark, far more sensitive than back-to-back cargo-bench runs. Fractions of a percent are detectable.

Default `tango/Cargo.toml` depends on `linear-srgb = "=0.6.11"` from crates.io — this build produces the **baseline** binary. To test a local WIP against it, uncomment the `[patch.crates-io]` block at the bottom, rebuild, and run the new binary in `compare` mode against the saved baseline. See `tango/README.md` for the one-line workflow.

## What it catches

Covers all six TF slice dispatchers (bt709 / pq / hlg, each direction) at three sizes (256, 4096, 8192) and four input distributions (uniform, all-small, all-large, HDR-luma cube) — 72 benches total.

Designed for the regression class reported in #18: tiny per-call and per-branch differences invisible to back-to-back cargo-bench runs. Example output (WIP from PR #16 vs published `=0.6.11`, Zen 4):

```
linear_to_hlg_uniform_256   [ 65.5 ns ...  57.9 ns ]  -11.68%*
linear_to_hlg_small_256     [ 56.8 ns ...  60.1 ns ]   +5.65%*
hlg_to_linear_uniform_4096  [  3.1 us ... 812.7 ns ]  -74.10%*
linear_to_pq_uniform_8192   [ 22.1 us ...   4.3 us ]  -80.63%*
```

Left = baseline, right = WIP; negative % = WIP faster; `*` = 95% CI excludes zero.

## Test plan

- [x] Builds against crates.io `=0.6.11` (baseline build)
- [x] Builds against local WIP via `[patch.crates-io]`
- [x] `compare` mode produces paired stats across all 72 benches
- [x] `tango/.gitignore` excludes `target/` and `Cargo.lock`
- [x] Not part of the main crate workspace — no effect on `cargo test` / `cargo bench` in the repo root