### PR TITLE
feat: SIMD polynomial srgb_u16_to_linear decode (closes #20)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,8 +237,9 @@ pub mod tokens;
 /// Provides scalar functions for all four transfer curves. SIMD `#[rite]`
 /// versions live in [`tokens`] (x4/x8/x16).
 ///
-/// Requires the `transfer` feature.
-#[cfg(feature = "transfer")]
+/// BT.709 / PQ / HLG scalars and transfer-specific rites require the
+/// `transfer` feature. sRGB-only helpers compile unconditionally so the
+/// extended-range slice functions (not gated on `transfer`) can link.
 pub mod tf;
 
 /// IEC 61966-2-1:1999 textbook sRGB transfer functions.

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1034,17 +1034,80 @@ pub fn linear_to_srgb_u8_slice(input: &[f32], output: &mut [u8]) {
 // u16 Batch Functions (LUT-based)
 // ============================================================================
 
-/// Convert sRGB u16 values to linear f32 using a lazily-initialized 65536-entry LUT.
+// ---------- SIMD polynomial path for srgb_u16_to_linear_slice ----------
+//
+// Normalizes u16→f32 via `*(1.0/65535.0)` (auto-vectorizes to
+// vpmovzxwd + vcvtdq2ps + vmulps) and evaluates the `S2L_P/Q` rational
+// polynomial with FMA. No LUT and no cache footprint — trades ~20 f32
+// ops per lane for freeing the 256KB decode LUT from the L2 budget.
+// Cross-tier output may differ by ≤1 u16 LSB (same precision envelope
+// as the encode slice).
+
+#[archmage::magetypes(v4(cfg(avx512)), v3, neon, wasm128, scalar)]
+fn srgb_u16_to_linear_slice_tier(token: Token, input: &[u16], output: &mut [f32]) {
+    use crate::rational_poly::{LINEAR_SCALE, S2L_P, S2L_Q, SRGB_THRESHOLD};
+    #[allow(non_camel_case_types)]
+    type f32x16 = g_f32x16<Token>;
+
+    let (in_chunks, in_rem) = input.as_chunks::<16>();
+    let (out_chunks, out_rem) = output.as_chunks_mut::<16>();
+    for (inp, out) in in_chunks.iter().zip(out_chunks.iter_mut()) {
+        // u16 → f32, normalized to [0, 1]. Scalar widening auto-vectorizes.
+        let mut f = [0.0f32; 16];
+        for i in 0..16 {
+            f[i] = inp[i] as f32;
+        }
+        let v = f32x16::from_array(token, f) * f32x16::splat(token, 1.0 / 65535.0);
+        let one = f32x16::splat(token, 1.0);
+
+        let linear_result = v * f32x16::splat(token, LINEAR_SCALE);
+
+        let yp = f32x16::splat(token, S2L_P[4]).mul_add(v, f32x16::splat(token, S2L_P[3]));
+        let yp = yp.mul_add(v, f32x16::splat(token, S2L_P[2]));
+        let yp = yp.mul_add(v, f32x16::splat(token, S2L_P[1]));
+        let yp = yp.mul_add(v, f32x16::splat(token, S2L_P[0]));
+
+        let yq = f32x16::splat(token, S2L_Q[4]).mul_add(v, f32x16::splat(token, S2L_Q[3]));
+        let yq = yq.mul_add(v, f32x16::splat(token, S2L_Q[2]));
+        let yq = yq.mul_add(v, f32x16::splat(token, S2L_Q[1]));
+        let yq = yq.mul_add(v, f32x16::splat(token, S2L_Q[0]));
+
+        let power_result = (yp / yq).min(one);
+
+        let mask = v.simd_le(f32x16::splat(token, SRGB_THRESHOLD));
+        let result = f32x16::blend(mask, linear_result, power_result);
+
+        // Match the scalar `srgb_to_linear_fast` early-exit: v >= 1.0 → 1.0.
+        // At u16=65535 the normalized v rounds to 1 + 2^-16 in f32, and the
+        // polynomial alone drifts a few ULP short of 1.0 — snap it back so
+        // srgb_u16_to_linear(65535) == 1.0 bit-exact (as the LUT does).
+        let ge_one = v.simd_ge(one);
+        let result = f32x16::blend(ge_one, one, result);
+        *out = result.to_array();
+    }
+
+    for (inp, out) in in_rem.iter().zip(out_rem.iter_mut()) {
+        *out = crate::scalar::srgb_u16_to_linear(*inp);
+    }
+}
+
+/// Convert sRGB u16 values to linear f32 via rational polynomial (SIMD).
 ///
-/// Pure table lookup, no math. The LUT is 256KB.
+/// Dispatches through `incant!` over `[v4, v3, neon, wasm128, scalar]` so
+/// the polynomial evaluates 4/8/16 wide. No LUT and no cache footprint —
+/// replaces the 256KB decode LUT on the slice path. Boundary values
+/// (0, 65535) map exactly to (0.0, 1.0). Output may differ from the
+/// scalar LUT by ≤1 f32 ULP at interior values.
 ///
 /// # Panics
 /// Panics if `input.len() != output.len()`.
+#[inline]
 pub fn srgb_u16_to_linear_slice(input: &[u16], output: &mut [f32]) {
     assert_eq!(input.len(), output.len());
-    for (inp, out) in input.iter().zip(output.iter_mut()) {
-        *out = crate::scalar::srgb_u16_to_linear(*inp);
-    }
+    incant!(
+        srgb_u16_to_linear_slice_tier(input, output),
+        [v4, v3, neon, wasm128, scalar]
+    )
 }
 
 // ---------- SIMD polynomial + quantize path for linear_to_srgb_u16_slice ----------

--- a/src/tf/mod.rs
+++ b/src/tf/mod.rs
@@ -32,10 +32,15 @@
 #[allow(unused_imports)]
 use num_traits::Float; // provides powf/sqrt via libm in no_std
 
-// Submodules with implementations
+// Submodules with implementations. sRGB + fast_math are always compiled
+// (the extended-range sRGB slice path in simd.rs is NOT gated on `transfer`
+// and depends on these); bt709/pq/hlg are opt-in via the `transfer` feature.
+#[cfg(feature = "transfer")]
 pub(crate) mod bt709;
 pub(crate) mod fast_math;
+#[cfg(feature = "transfer")]
 pub(crate) mod hlg;
+#[cfg(feature = "transfer")]
 pub(crate) mod pq;
 pub(crate) mod srgb;
 
@@ -63,15 +68,18 @@ pub fn linear_to_srgb(v: f32) -> f32 {
     crate::rational_poly::linear_to_srgb_fast(v)
 }
 
+#[cfg(feature = "transfer")]
 pub use bt709::{bt709_to_linear, linear_to_bt709};
+#[cfg(feature = "transfer")]
 pub use hlg::{hlg_to_linear, linear_to_hlg};
+#[cfg(feature = "transfer")]
 pub use pq::{linear_to_pq, pq_to_linear};
 
 // =============================================================================
 // Tests
 // =============================================================================
 
-#[cfg(test)]
+#[cfg(all(test, feature = "transfer"))]
 mod tests {
     use super::*;
 

--- a/src/tokens/x8.rs
+++ b/src/tokens/x8.rs
@@ -8,9 +8,10 @@
 
 use archmage::rite;
 
-pub use archmage::X64V3Token;
+pub use archmage::{NeonToken, Wasm128Token, X64V3Token};
 
 use magetypes::simd::f32x8 as mt_f32x8;
+use magetypes::simd::generic::f32x8 as gen_f32x8;
 
 // sRGB transfer function constants (C0-continuous moxcms, matching rational polynomial)
 const SRGB_LINEAR_THRESHOLD: f32 = 0.039_293_37;
@@ -243,6 +244,59 @@ pub fn srgb_u8_to_linear_slice_v3(_token: X64V3Token, input: &[u8], output: &mut
     }
 }
 
+// ============================================================================
+// x8 SIMD functions — u16↔f32 (rational polynomial, no LUT)
+// ============================================================================
+
+/// Convert 8 sRGB u16 values to linear f32 via rational polynomial.
+///
+/// Pure SIMD — no LUT, no cache footprint. Normalizes u16 to [0, 1] via
+/// `*(1.0/65535.0)` and applies the C0-continuous `S2L_P/Q` rational
+/// polynomial. Boundary values (0, 65535) map exactly to (0.0, 1.0).
+///
+/// The `#[magetypes(...)]` macro generates `_v3`, `_neon`, `_wasm128`
+/// variants from this single body; f32x8 is native on V3 and polyfills
+/// to 2×f32x4 on NEON / WASM128 (fully inlined). Call from inside an
+/// `#[arcane]` function for zero-overhead inlining.
+#[archmage::magetypes(v3, neon, wasm128)]
+#[rite]
+pub fn srgb_u16_to_linear(token: Token, srgb: [u16; 8]) -> [f32; 8] {
+    use crate::rational_poly::{S2L_P, S2L_Q};
+    #[allow(non_camel_case_types)]
+    type f32x8 = gen_f32x8<Token>;
+
+    // u16 → f32 / 65535: auto-vectorizes to vpmovzxwd + vcvtdq2ps + vmulps
+    // (or the NEON / WASM equivalents).
+    let mut f = [0.0f32; 8];
+    for i in 0..8 {
+        f[i] = srgb[i] as f32;
+    }
+    let v = f32x8::from_array(token, f) * f32x8::splat(token, 1.0 / 65535.0);
+    let one = f32x8::splat(token, 1.0);
+
+    let linear_result = v * f32x8::splat(token, LINEAR_SCALE);
+
+    let yp = f32x8::splat(token, S2L_P[4]).mul_add(v, f32x8::splat(token, S2L_P[3]));
+    let yp = yp.mul_add(v, f32x8::splat(token, S2L_P[2]));
+    let yp = yp.mul_add(v, f32x8::splat(token, S2L_P[1]));
+    let yp = yp.mul_add(v, f32x8::splat(token, S2L_P[0]));
+
+    let yq = f32x8::splat(token, S2L_Q[4]).mul_add(v, f32x8::splat(token, S2L_Q[3]));
+    let yq = yq.mul_add(v, f32x8::splat(token, S2L_Q[2]));
+    let yq = yq.mul_add(v, f32x8::splat(token, S2L_Q[1]));
+    let yq = yq.mul_add(v, f32x8::splat(token, S2L_Q[0]));
+
+    let power_result = (yp / yq).min(one);
+
+    let mask = v.simd_lt(f32x8::splat(token, SRGB_LINEAR_THRESHOLD));
+    let result = f32x8::blend(mask, linear_result, power_result);
+    // Match the scalar `srgb_to_linear_fast` early-exit so u16=65535 → 1.0
+    // bit-exact: the normalized v rounds to 1 + 2^-16 in f32 and the
+    // polynomial alone drifts a few ULP short of 1.0 at v=1.
+    let ge_one = v.simd_ge(one);
+    f32x8::blend(ge_one, one, result).to_array()
+}
+
 /// Convert 8 linear f32 values to sRGB u8 via LUT. Input clamped to \[0, 1\].
 ///
 /// Uses a 4096-entry const LUT with bitmask indexing (`& 0xFFF`) for
@@ -268,6 +322,66 @@ pub fn linear_to_srgb_u8_v3(token: X64V3Token, linear: [f32; 8]) -> [u8; 8] {
         lut[arr[5] as usize & 0xFFF],
         lut[arr[6] as usize & 0xFFF],
         lut[arr[7] as usize & 0xFFF],
+    ]
+}
+
+/// Convert 8 linear f32 values to sRGB u16 via rational polynomial.
+///
+/// Pure SIMD — no LUT, no cache footprint. Clamps to [0, 1], applies the
+/// C0-continuous `L2S_P/Q` rational polynomial on √x, then scales by
+/// 65535 + 0.5 and truncates to u16. Perfect roundtrip with the decode
+/// polynomial. Inputs ≥ 1.0 map to 65535 bit-exact; inputs ≤ 0.0 map to 0.
+///
+/// The `#[magetypes(...)]` macro generates `_v3`, `_neon`, `_wasm128`
+/// variants from this single body; f32x8 is native on V3 and polyfills
+/// to 2×f32x4 on NEON / WASM128 (fully inlined). Call from inside an
+/// `#[arcane]` function for zero-overhead inlining.
+#[archmage::magetypes(v3, neon, wasm128)]
+#[rite]
+pub fn linear_to_srgb_u16(token: Token, linear: [f32; 8]) -> [u16; 8] {
+    use crate::rational_poly::{L2S_P, L2S_Q};
+    #[allow(non_camel_case_types)]
+    type f32x8 = gen_f32x8<Token>;
+
+    let v = f32x8::from_array(token, linear);
+    let zero = f32x8::zero(token);
+    let one = f32x8::splat(token, 1.0);
+    let clamped = v.max(zero).min(one);
+
+    let linear_result = clamped * f32x8::splat(token, TWELVE_92);
+
+    let x = clamped.sqrt();
+    let yp = f32x8::splat(token, L2S_P[4]).mul_add(x, f32x8::splat(token, L2S_P[3]));
+    let yp = yp.mul_add(x, f32x8::splat(token, L2S_P[2]));
+    let yp = yp.mul_add(x, f32x8::splat(token, L2S_P[1]));
+    let yp = yp.mul_add(x, f32x8::splat(token, L2S_P[0]));
+
+    let yq = f32x8::splat(token, L2S_Q[4]).mul_add(x, f32x8::splat(token, L2S_Q[3]));
+    let yq = yq.mul_add(x, f32x8::splat(token, L2S_Q[2]));
+    let yq = yq.mul_add(x, f32x8::splat(token, L2S_Q[1]));
+    let yq = yq.mul_add(x, f32x8::splat(token, L2S_Q[0]));
+
+    let power_result = (yp / yq).min(one);
+
+    let thresh_mask = clamped.simd_lt(f32x8::splat(token, LINEAR_THRESHOLD));
+    let srgb = f32x8::blend(thresh_mask, linear_result, power_result);
+
+    // Force 1.0 for inputs >= 1.0 so the u16 endpoint lands exactly on 65535
+    // (mirrors the clamp in linear_to_srgb_u16_slice_tier).
+    let ge_one = v.simd_ge(one);
+    let srgb = f32x8::blend(ge_one, one, srgb);
+
+    let scaled = srgb.mul_add(f32x8::splat(token, 65535.0), f32x8::splat(token, 0.5));
+    let idx = scaled.to_i32().to_array();
+    [
+        idx[0] as u16,
+        idx[1] as u16,
+        idx[2] as u16,
+        idx[3] as u16,
+        idx[4] as u16,
+        idx[5] as u16,
+        idx[6] as u16,
+        idx[7] as u16,
     ]
 }
 

--- a/tango/benches/regression.rs
+++ b/tango/benches/regression.rs
@@ -8,7 +8,7 @@ use std::hint::black_box;
 
 use linear_srgb::default::{
     bt709_to_linear_slice, hlg_to_linear_slice, linear_to_bt709_slice, linear_to_hlg_slice,
-    linear_to_pq_slice, pq_to_linear_slice,
+    linear_to_pq_slice, linear_to_srgb_u16_slice, pq_to_linear_slice, srgb_u16_to_linear_slice,
 };
 use tango_bench::{IntoBenchmarks, benchmark_fn, tango_benchmarks, tango_main};
 
@@ -97,6 +97,40 @@ fn bench_fn(
     })
 }
 
+/// srgb_u16 → linear f32: input is [u16; N] in sRGB gamma; compares the
+/// new SIMD polynomial decode against 0.6.11's scalar 256 KB LUT loop.
+fn bench_u16_decode() -> impl IntoIterator<Item = tango_bench::Benchmark> {
+    SIZES.iter().map(|&n| {
+        let input: Vec<u16> = (0..n).map(|i| ((i * 65535) / n.max(1)) as u16).collect();
+        let label = leak_label(&format!("srgb_u16_to_linear_{n}"));
+        benchmark_fn(label, move |b| {
+            let src = input.clone();
+            let mut out = vec![0.0f32; src.len()];
+            b.iter(move || {
+                srgb_u16_to_linear_slice(black_box(&src), &mut out);
+            })
+        })
+    })
+}
+
+/// linear f32 → srgb_u16: input is [f32; N] in [0, 1]; compares SIMD
+/// rational polynomial encode against 0.6.11's SIMD-clamp + sqrt-LUT
+/// (same implementation lives on both — this is a parity check, not a
+/// regression target).
+fn bench_u16_encode() -> impl IntoIterator<Item = tango_bench::Benchmark> {
+    SIZES.iter().map(|&n| {
+        let input = dist_uniform(n);
+        let label = leak_label(&format!("linear_to_srgb_u16_{n}"));
+        benchmark_fn(label, move |b| {
+            let src = input.clone();
+            let mut out = vec![0u16; src.len()];
+            b.iter(move || {
+                linear_to_srgb_u16_slice(black_box(&src), &mut out);
+            })
+        })
+    })
+}
+
 fn benchmarks() -> impl IntoBenchmarks {
     let mut out: Vec<tango_bench::Benchmark> = Vec::new();
     out.extend(bench_fn("linear_to_hlg", linear_to_hlg_slice));
@@ -105,6 +139,8 @@ fn benchmarks() -> impl IntoBenchmarks {
     out.extend(bench_fn("bt709_to_linear", bt709_to_linear_slice));
     out.extend(bench_fn("linear_to_pq", linear_to_pq_slice));
     out.extend(bench_fn("pq_to_linear", pq_to_linear_slice));
+    out.extend(bench_u16_decode());
+    out.extend(bench_u16_encode());
     out
 }
 

--- a/tests/simd_consistency.rs
+++ b/tests/simd_consistency.rs
@@ -11,7 +11,7 @@ use linear_srgb::default::{
     linear_to_srgb_slice, linear_to_srgb_u8_rgba_slice, linear_to_srgb_u8_slice,
     linear_to_srgb_u16_rgba_slice, linear_to_srgb_u16_rgba_slice_fast, linear_to_srgb_u16_slice,
     linear_to_srgb_u16_slice_fast, srgb_to_linear_slice, srgb_u8_to_linear_slice,
-    unpremultiply_linear_to_srgb_u8_rgba_slice,
+    srgb_u16_to_linear_slice, unpremultiply_linear_to_srgb_u8_rgba_slice,
 };
 
 /// Hash a byte slice deterministically (FNV-1a).
@@ -90,6 +90,62 @@ fn max_u16_diff(a: &[u16], b: &[u16]) -> u16 {
         .map(|(x, y)| x.abs_diff(*y))
         .max()
         .unwrap_or(0)
+}
+
+/// Max absolute f32 ULP difference between two slices (in ULPs at 1.0).
+fn max_f32_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0f32, f32::max)
+}
+
+#[test]
+fn srgb_u16_to_linear_all_tiers_close() {
+    // New SIMD polynomial path — cross-tier precision envelope matches the
+    // encode direction (~1 f32 ULP of cross-tier variance). Reference here
+    // is the first tier; others must be within a few ULPs.
+    let input: Vec<u16> = (0..4096u32).map(|i| (i * 16) as u16).collect();
+    let mut reference: Option<Vec<f32>> = None;
+
+    let _ = for_each_token_permutation(CompileTimePolicy::Warn, |perm| {
+        let mut output = vec![0.0f32; input.len()];
+        srgb_u16_to_linear_slice(&input, &mut output);
+
+        if let Some(ref ref_out) = reference {
+            let diff = max_f32_abs_diff(ref_out, &output);
+            // 1 f32 ULP at 1.0 is 2^-23 ≈ 1.19e-7; allow a few ULPs for
+            // FMA rounding differences across tiers.
+            assert!(
+                diff < 5e-7,
+                "srgb_u16_to_linear under '{}': max_f32_abs_diff={diff:.2e} (expected < 5e-7)",
+                perm.label,
+            );
+        } else {
+            reference = Some(output);
+        }
+    });
+}
+
+#[test]
+fn srgb_u16_to_linear_roundtrip_boundaries() {
+    // Boundary values must map exactly: 0 → 0.0, 65535 → 1.0 on every tier.
+    let input: Vec<u16> = vec![0, 1, 65534, 65535];
+
+    let _ = for_each_token_permutation(CompileTimePolicy::Warn, |perm| {
+        let mut output = vec![0.0f32; input.len()];
+        srgb_u16_to_linear_slice(&input, &mut output);
+        assert_eq!(
+            output[0], 0.0,
+            "srgb_u16_to_linear(0) != 0.0 under '{}': got {}",
+            perm.label, output[0]
+        );
+        assert_eq!(
+            output[3], 1.0,
+            "srgb_u16_to_linear(65535) != 1.0 under '{}': got {}",
+            perm.label, output[3]
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
Closes #20.

## Summary

Adds a SIMD polynomial path for `srgb_u16_to_linear_slice`, mirroring the existing SIMD polynomial path for `linear_to_srgb_u16_slice`. The slice dispatcher now evaluates the `S2L_P/Q` rational polynomial 4/8/16-wide across `[v4, v3, neon, wasm128, scalar]` instead of looping over `crate::scalar::srgb_u16_to_linear` — retiring the 256 KB decode LUT from the hot path.

Also adds the matching fixed-array rite `tokens::x8::srgb_u16_to_linear_v3(X64V3Token, [u16; 8]) -> [f32; 8]` for callers that want to invoke it from their own `#[arcane]` context.

## Endpoint correctness

The normalized v at u16 = 65535 rounds to `1 + 2^-16` in f32 (f32(1/65535) rounds up by ~1 ULP, so 65535 × that overshoots 1.0 by ~128 ULPs at 1.0). The polynomial alone drifts a few ULP short of 1.0 at the boundary. The scalar `srgb_to_linear_fast` avoids this via an explicit `if gamma >= 1.0 { return 1.0 }` early-exit. The SIMD path mirrors it with a `blend(v >= 1, 1, result)` at the tail, keeping `srgb_u16_to_linear(65535) == 1.0` bit-exact across all tiers.

## Tests

- `tests/simd_consistency.rs`:
  - `srgb_u16_to_linear_all_tiers_close` — max f32 diff across tiers < 5e-7 (a few ULPs, matches the encode-side tolerance envelope)
  - `srgb_u16_to_linear_roundtrip_boundaries` — 0 → 0.0 and 65535 → 1.0 bit-exact on every tier
- `tests/brute_force.rs`:
  - `every_u16_roundtrip` — unchanged: max u16 roundtrip diff still 0, 100% exact on the sqrt-LUT encode side
  - `every_u16_vs_f64_reference` — unchanged: max f64 error still < 1e-5 across all 65536 u16 inputs
- 155 lib + 58 brute_force + 13 simd_consistency (+2 new) + 30 doctests all pass
- Cross-target builds clean on aarch64-unknown-linux-gnu, wasm32-unknown-unknown

## Test plan

- [x] `cargo test --all-features` locally — all pass
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Cross-builds: aarch64, wasm32
- [ ] CI green on all platforms