### PR TITLE
docs(linear-srgb): state f32 [0,1] range + u8 round-trip exactness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
 
 ### Fixed
 
+- docs(readme): state f32 linear normalization range `[0, 1]` + u8 encoder
+  rounding/round-trip exactness — found by insulated-developer test. The
+  README documented the u16 encode precision but left the f32 linear range
+  implied and the u8 encode behavior unstated; now the Type-conversions
+  section notes the `[0.0, 1.0]` normalization (u8/u16 LUT decode + f32
+  single-value API) and the u8 encode (rounds to nearest, `u8 → linear → u8`
+  exact within ±1 level, unlike the bit-exact `linear_to_srgb_u16` path).
+
 - **Slice tail used a different transfer curve than the SIMD body.** The
   remainder loops in `srgb_to_linear_slice` / `linear_to_srgb_slice` (and
   their RGBA variants) converted the trailing up-to-15 elements of any

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ constraint. The `_rgba_` variants treat the buffer as tightly-packed RGBA
 sRGB-decoded and the alpha component is passed through (as `a/255` for the u8
 variants), not sRGB-decoded.
 
+**Linear range is normalized `[0.0, 1.0]`.** The u8/u16 LUT decode paths map the
+integer black point to `0.0` and the integer white point to `1.0` (u8: `0 → 0.0`,
+`255 → 1.0`; u16: `0 → 0.0`, `65535 → 1.0`), so the linear f32 output lands in
+`[0.0, 1.0]`. The single-value f32 API (`srgb_to_linear` / `linear_to_srgb`)
+expects and returns the same normalized `[0, 1]` range and clamps inputs to it.
+For values outside `[0, 1]` (HDR, cross-gamut matrix output), use the
+extended-range functions below instead.
+
 ### u16 encode: exact vs fast
 
 Two paths for linear f32 → sRGB u16, depending on whether you need perfect
@@ -97,6 +105,14 @@ let fast = linear_to_srgb_u16_fast(linear);
 
 Slice variants: `linear_to_srgb_u16_slice` / `linear_to_srgb_u16_slice_fast`,
 `linear_to_srgb_u16_rgba_slice` / `linear_to_srgb_u16_rgba_slice_fast`.
+
+**u8 encode** (`linear_to_srgb_u8` / `linear_to_srgb_u8_slice`) rounds to the
+nearest level (LUT index `linear * 4095 + 0.5`) and is accurate to within ±1 u8
+level vs exact computation. The `u8 → linear → u8` round-trip is exact to within
+**±1 level** (not bit-exact 0 like the `linear_to_srgb_u16` polynomial path) —
+the LUT-quantized encode can land one level off near segment boundaries. For most
+8-bit image work this is invisible; if you need a guaranteed-exact round-trip,
+stay in u16.
 
 ### Premultiplied alpha (fused, single-pass)
 


### PR DESCRIPTION
An "insulated external developer" usability test (an agent given only the README) found linear-srgb excellent — compiles first-try — but flagged two implied-but-unstated facts. This closes both.

## Gaps found
1. **f32 linear normalization range was only implied** ([0,1]?). The README documented u16 encode precision and the slice length contract well, but never stated the linear range.
2. **u8 encoder round-trip exactness/rounding was unstated.** The README gave ±-level figures for u16 but not u8.

## Changes (README + CHANGELOG only — no source/doctest)
- **Type conversions:** added a note that the linear range is normalized `[0.0, 1.0]` — the u8/u16 LUT decode paths map black→`0.0` and white→`1.0` (u8 `255→1.0`, u16 `65535→1.0`), and the single-value f32 API (`srgb_to_linear`/`linear_to_srgb`) expects/returns the same `[0,1]` range and clamps to it.
- **u16 encode section:** added a parallel u8-encode note — `linear_to_srgb_u8` rounds to nearest (`linear * 4095 + 0.5` LUT index, ±1 u8 level vs exact), and the `u8 → linear → u8` round-trip is exact within **±1 level** (not bit-exact 0 like the `linear_to_srgb_u16` polynomial path).

## Verified against source (not invented)
- Linear range / decode: `src/scalar.rs:379` (u8 LUT `srgb = i / 255.0` → 0→0.0, 255→1.0; `test_u8_conversion` line 528 asserts `srgb_u8_to_linear(0) == 0.0`); `src/lut.rs:42-44` (`LinearizationTable::new` uses `(N-1)` as max); u16 boundaries `src/scalar.rs:547-548` (`0→0.0`, `65535→1.0`).
- f32 single-value API clamps to `[0,1]`: `src/rational_poly.rs:189-200` and `:210-222` (the `default::srgb_to_linear`/`linear_to_srgb` exports return 0.0 below 0 and 1.0 at/above 1).
- u8 encode rounding: `src/scalar.rs:213-216` (`(linear.clamp(0,1) * 4095.0 + 0.5) as usize & 0xFFF`, doc states "Max error: ±1 u8 level").
- u8 round-trip is ±1, not 0: `src/scalar.rs:533-541` and `src/lut.rs:317-328` both assert `(i - back).abs() <= 1`. (Contrast: u16 polynomial round-trip is asserted bit-exact at `src/scalar.rs:571-579`.)

The README's length-contract panic note was left untouched.